### PR TITLE
There may be identical callbacks at different memory locations

### DIFF
--- a/lem.lua
+++ b/lem.lua
@@ -53,8 +53,9 @@ end
 
 function lem:remove(eventname, callback)
   if not self:eventExists(eventname) then return self end
+  local callbackString = string.dump(callback)
   for k, v in pairs(self:getHandlers(eventname)) do
-    if v == callback then
+    if string.dump(v) == callbackString then
       self.handlers[eventname][k] = nil
     end
   end


### PR DESCRIPTION
You were comparing the memory addresses of the callbacks, but one might have two identical functions (at different memory addresses) that would get flagged as different in that loop. My suggestion is comparing the compiled functions (as strings) to see if they are the same.

``` lua
function test(params)
    print("Test!")
end
lem:on("evt", test)

-- some code that clones `test` such as [1] that eventually moves the clone back into `test`
local clone = clone_function(test)
test = clone

lem:remove("evt", test) -- Does nothing
lem:emit("evt", {}) -- Still prints "Test!"
```

[1] [Leafo's `clone_function`](http://leafo.net/guides/function-cloning-in-lua.html#clone-function-implementation)
